### PR TITLE
Remove temporary fix for CVE-2021-22945

### DIFF
--- a/nginx-base/alpine-nginx/Dockerfile
+++ b/nginx-base/alpine-nginx/Dockerfile
@@ -4,9 +4,7 @@ ENV PARSE_TEMPLATE_VERSION=v1.0.0 \
     PARSE_TEMPLATE_HASH=8d1dc39e701b938f4874f3f8130cd3a324e7fa4697af36541918f9398dd61223
 
 RUN set -exu \
- # fixing curl versions there to fix CVE-2021-22945
- && apk add --no-cache --virtual build-deps curl~=7.79.1-r0 \
- && apk add --no-cache libcurl~=7.79.1-r0 xz-libs~=5.2.5-r1 xz~=5.2.5-r1 \
+ && apk add --no-cache --virtual build-deps curl \
  && curl -L -o /usr/bin/parse-template https://github.com/cocreators-ee/parse-template/releases/download/${PARSE_TEMPLATE_VERSION}/parse-template-linux-amd64 \
  && echo "${PARSE_TEMPLATE_HASH}  /usr/bin/parse-template" | sha256sum -c \
  && chmod +x /usr/bin/parse-template \


### PR DESCRIPTION
Latest nginx:stable-alpine now ships curl/libcurl 7.83.1. That both has the CVE fixed and also causes the builds to crash, as apk won't install 7.79.x on top of the newer version.

In essence reverts the fixes from bf0584b85e1890e48446d797db481654cb46379e

Note: xz-libs-5.2.5-r1 is included by default already, so removing lock for that as well. However note that xz is not by default installed. I don't think we need it for anything, but pointing it out jus tin case that it won't be installed by default now after these changes.