### PR TITLE
HOTFIX: Lock pnpm version on Node14

### DIFF
--- a/nodejs-base/ubuntu20.04-node14/docker/scripts/install_node.sh
+++ b/nodejs-base/ubuntu20.04-node14/docker/scripts/install_node.sh
@@ -11,4 +11,4 @@ apt-get update
 apt-get install -y --no-install-recommends nodejs
 
 # Install sane package managers
-npm install -g pnpm yarn
+npm install -g pnpm@7.30.5 yarn

--- a/python-base/ubuntu20.04-python3.9-nginx-node/docker/scripts/install_node.sh
+++ b/python-base/ubuntu20.04-python3.9-nginx-node/docker/scripts/install_node.sh
@@ -11,4 +11,4 @@ apt-get update
 apt-get install -y --no-install-recommends nodejs
 
 # Install sane package managers
-npm install -g pnpm yarn
+npm install -g pnpm@7.30.5 yarn


### PR DESCRIPTION
Lock the pnpm version on Node14 to one that works on Node14