### PR TITLE
Update poetry to version 1.5.0

### DIFF
--- a/.github/workflows/keepalive.yaml
+++ b/.github/workflows/keepalive.yaml
@@ -32,8 +32,8 @@ jobs:
               # Reset repo state
               git checkout --orphan "${BRANCH}"
               date +%Y-%m-%dT%H:%M:%S > .github/keepalive.txt
-              git reset 
-              git add .github/keepalive.txt 
+              git reset
+              git add .github/keepalive.txt
               git commit --message "${MESSAGE}"
               git push -f --set-upstream origin "${BRANCH}"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: shellcheck
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/python-base/ubuntu20.04-python3.9-nginx-node/config.yaml
+++ b/python-base/ubuntu20.04-python3.9-nginx-node/config.yaml
@@ -5,12 +5,12 @@ tags:
   - lts-python-nginx-node14
   - ubuntu-python3.9-nginx-node
   - ubuntu-python3.9-nginx-node14
-  - poetry1.2.2-nginx-node14
-  - lts-poetry1.2.2-nginx-node14
-  - ubuntu-python-poetry1.2.2-nginx-node14
-  - ubuntu-python3.9-poetry1.2.2-nginx-node
-  - ubuntu-python3.9-poetry1.2.2-nginx-node14
-  - ubuntu20.04-python-poetry1.2.2-nginx-node
-  - ubuntu20.04-python-poetry1.2.2-nginx-node14
-  - ubuntu20.04-python3.9-poetry1.2.2-nginx-node
-  - ubuntu20.04-python3.9-poetry1.2.2-nginx-node14
+  - poetry1.5.0-nginx-node14
+  - lts-poetry1.5.0-nginx-node14
+  - ubuntu-python-poetry1.5.0-nginx-node14
+  - ubuntu-python3.9-poetry1.5.0-nginx-node
+  - ubuntu-python3.9-poetry1.5.0-nginx-node14
+  - ubuntu20.04-python-poetry1.5.0-nginx-node
+  - ubuntu20.04-python-poetry1.5.0-nginx-node14
+  - ubuntu20.04-python3.9-poetry1.5.0-nginx-node
+  - ubuntu20.04-python3.9-poetry1.5.0-nginx-node14

--- a/python-base/ubuntu20.04-python3.9-nginx/config.yaml
+++ b/python-base/ubuntu20.04-python3.9-nginx/config.yaml
@@ -1,6 +1,6 @@
 tags:
   - ubuntu20.04-python-nginx
   - ubuntu-python3.9-nginx
-  - ubuntu-python3.9-poetry1.2.2-nginx
-  - ubuntu20.04-python-poetry1.2.2-nginx
-  - ubuntu20.04-python3.9-poetry1.2.2-nginx
+  - ubuntu-python3.9-poetry1.5.0-nginx
+  - ubuntu20.04-python-poetry1.5.0-nginx
+  - ubuntu20.04-python3.9-poetry1.5.0-nginx

--- a/python-base/ubuntu20.04-python3.9/Dockerfile
+++ b/python-base/ubuntu20.04-python3.9/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     LC_ALL=C.UTF-8 \
     PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
     POETRY_HOME="/usr/local/poetry" \
-    POETRY_VERSION="1.4.2" \
+    POETRY_VERSION="1.5.0" \
     PYTHONUNBUFFERED=1 \
     PYTHON_VERSION="3.9" \
     TZ="UTC" \

--- a/python-base/ubuntu20.04-python3.9/Dockerfile
+++ b/python-base/ubuntu20.04-python3.9/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     LC_ALL=C.UTF-8 \
     PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
     POETRY_HOME="/usr/local/poetry" \
-    POETRY_VERSION="1.2.2" \
+    POETRY_VERSION="1.4.2" \
     PYTHONUNBUFFERED=1 \
     PYTHON_VERSION="3.9" \
     TZ="UTC" \

--- a/python-base/ubuntu20.04-python3.9/config.yaml
+++ b/python-base/ubuntu20.04-python3.9/config.yaml
@@ -1,9 +1,9 @@
 tags:
   - ubuntu20.04-python
   - ubuntu-python3.9
-  - poetry1.2.2
-  - lts-poetry1.2.2
-  - ubuntu-python-poetry1.2.2
-  - ubuntu-python3.9-poetry1.2.2
-  - ubuntu20.04-python-poetry1.2.2
-  - ubuntu20.04-python3.9-poetry1.2.2
+  - poetry1.5.0
+  - lts-poetry1.5.0
+  - ubuntu-python-poetry1.5.0
+  - ubuntu-python3.9-poetry1.5.0
+  - ubuntu20.04-python-poetry1.5.0
+  - ubuntu20.04-python3.9-poetry1.5.0

--- a/python-base/ubuntu22.04-python3.10-nginx-node/config.yaml
+++ b/python-base/ubuntu22.04-python3.10-nginx-node/config.yaml
@@ -7,15 +7,15 @@ tags:
   - lts-python-nginx-node16
   - ubuntu-python3.10-nginx-node
   - ubuntu-python3.10-nginx-node16
-  - poetry1.2.2-nginx-node
-  - poetry1.2.2-nginx-node16
-  - lts-poetry1.2.2-nginx-node
-  - lts-poetry1.2.2-nginx-node16
-  - ubuntu-python-poetry1.2.2-nginx-node
-  - ubuntu-python-poetry1.2.2-nginx-node16
-  - ubuntu-python3.10-poetry1.2.2-nginx-node
-  - ubuntu-python3.10-poetry1.2.2-nginx-node16
-  - ubuntu22.04-python-poetry1.2.2-nginx-node
-  - ubuntu22.04-python-poetry1.2.2-nginx-node16
-  - ubuntu22.04-python3.10-poetry1.2.2-nginx-node
-  - ubuntu22.04-python3.10-poetry1.2.2-nginx-node16
+  - poetry1.5.0-nginx-node
+  - poetry1.5.0-nginx-node16
+  - lts-poetry1.5.0-nginx-node
+  - lts-poetry1.5.0-nginx-node16
+  - ubuntu-python-poetry1.5.0-nginx-node
+  - ubuntu-python-poetry1.5.0-nginx-node16
+  - ubuntu-python3.10-poetry1.5.0-nginx-node
+  - ubuntu-python3.10-poetry1.5.0-nginx-node16
+  - ubuntu22.04-python-poetry1.5.0-nginx-node
+  - ubuntu22.04-python-poetry1.5.0-nginx-node16
+  - ubuntu22.04-python3.10-poetry1.5.0-nginx-node
+  - ubuntu22.04-python3.10-poetry1.5.0-nginx-node16

--- a/python-base/ubuntu22.04-python3.10-nginx-node18/config.yaml
+++ b/python-base/ubuntu22.04-python3.10-nginx-node18/config.yaml
@@ -3,9 +3,9 @@ tags:
   - ubuntu22.04-python-nginx-node18
   - lts-python-nginx-node18
   - ubuntu-python3.10-nginx-node18
-  - poetry1.2.2-nginx-node18
-  - lts-poetry1.2.2-nginx-node18
-  - ubuntu-python-poetry1.2.2-nginx-node18
-  - ubuntu-python3.10-poetry1.2.2-nginx-node18
-  - ubuntu22.04-python-poetry1.2.2-nginx-node18
-  - ubuntu22.04-python3.10-poetry1.2.2-nginx-node18
+  - poetry1.5.0-nginx-node18
+  - lts-poetry1.5.0-nginx-node18
+  - ubuntu-python-poetry1.5.0-nginx-node18
+  - ubuntu-python3.10-poetry1.5.0-nginx-node18
+  - ubuntu22.04-python-poetry1.5.0-nginx-node18
+  - ubuntu22.04-python3.10-poetry1.5.0-nginx-node18

--- a/python-base/ubuntu22.04-python3.10-nginx/config.yaml
+++ b/python-base/ubuntu22.04-python3.10-nginx/config.yaml
@@ -3,9 +3,9 @@ tags:
   - ubuntu22.04-python-nginx
   - lts-python-nginx
   - ubuntu-python3.10-nginx
-  - poetry1.2.2-nginx
-  - lts-poetry1.2.2-nginx
-  - ubuntu-python-poetry1.2.2-nginx
-  - ubuntu-python3.10-poetry1.2.2-nginx
-  - ubuntu22.04-python-poetry1.2.2-nginx
-  - ubuntu22.04-python3.10-poetry1.2.2-nginx
+  - poetry1.5.0-nginx
+  - lts-poetry1.5.0-nginx
+  - ubuntu-python-poetry1.5.0-nginx
+  - ubuntu-python3.10-poetry1.5.0-nginx
+  - ubuntu22.04-python-poetry1.5.0-nginx
+  - ubuntu22.04-python3.10-poetry1.5.0-nginx

--- a/python-base/ubuntu22.04-python3.10/Dockerfile
+++ b/python-base/ubuntu22.04-python3.10/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     LC_ALL=C.UTF-8 \
     PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
     POETRY_HOME="/usr/local/poetry" \
-    POETRY_VERSION="1.2.2" \
+    POETRY_VERSION="1.4.2" \
     PYTHONUNBUFFERED=1 \
     PYTHON_VERSION="3.10" \
     TZ="UTC" \

--- a/python-base/ubuntu22.04-python3.10/Dockerfile
+++ b/python-base/ubuntu22.04-python3.10/Dockerfile
@@ -8,7 +8,7 @@ ENV \
     LC_ALL=C.UTF-8 \
     PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
     POETRY_HOME="/usr/local/poetry" \
-    POETRY_VERSION="1.4.2" \
+    POETRY_VERSION="1.5.0" \
     PYTHONUNBUFFERED=1 \
     PYTHON_VERSION="3.10" \
     TZ="UTC" \

--- a/python-base/ubuntu22.04-python3.10/config.yaml
+++ b/python-base/ubuntu22.04-python3.10/config.yaml
@@ -1,4 +1,4 @@
 tags:
   - ubuntu-python3.10
-  - ubuntu-python3.10-poetry1.2.2
-  - ubuntu22.04-python3.10-poetry1.2.2
+  - ubuntu-python3.10-poetry1.5.0
+  - ubuntu22.04-python3.10-poetry1.5.0


### PR DESCRIPTION
Update poetry to version 1.5.0. I checked the change log https://python-poetry.org/history/ for the update to poetry version 1.5.0 and there are no breaking changes so I decided to update to poetry version 1.5.0. Also, I install Poetry version 1.5.0 locally and ran the developer-portal project locally with no issues. 

Built `ubuntu20.04-python3.9` Dockerfile locally and tested the image as a base image for the `product-gateway` repo.

The `product-gateway` Dockerfile was built successfully and I ran the image with no issues. I also confirmed the poetry version running inside the container. 

NB. Trivy security scan is failing for images with `nodejs ` installed.

Nodejs vulnerabilities:

X.400 address type confusion in X.509 GeneralName
CVE-2023-0286

Regular Expression Denial of Service (ReDoS) vulnerability
CVE-2022-25881

I couldn't find a patch for these issues so I added them to `.trivyignore` for now. Hopefully, the node source script will patch the issue soon. 


