### PR TITLE
Rename action

### DIFF
--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -1,4 +1,4 @@
-name: Build and upload images to Docker hub
+name: Build and upload images
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Images are no longer uploaded to Docker hub, so reflect that in the name of the workflow/action.