### PR TITLE
Fix multi-start for api user

### DIFF
--- a/python-base/ubuntu22.04-python3.10/docker/scripts/install_multi_start.sh
+++ b/python-base/ubuntu22.04-python3.10/docker/scripts/install_multi_start.sh
@@ -8,5 +8,5 @@ python3.10 -m pip install --user -U pipx
 /root/.local/bin/pipx ensurepath
 export PATH="/root/.local/bin:$PATH"
 
-# Install multi-start
-pipx install multi-start
+# Install multi-start and make it available for all users
+PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install multi-start


### PR DESCRIPTION
Make multi-start available in non-root environments

```
 ❱ docker run --rm -it docker.io/library/python-base:ubuntu22.04-python3.10 /bin/bash
root@cf55322f527b:/src# multi-start
At least one service must be enabled
root@cf55322f527b:/src# su api
api@cf55322f527b:/src$ multi-start
At least one service must be enabled
api@cf55322f527b:/src$ 
```