### PR TITLE
Add multi-start for node image

### DIFF
--- a/nodejs-base/ubuntu22.04-node18/docker/base-prepare.sh
+++ b/nodejs-base/ubuntu22.04-node18/docker/base-prepare.sh
@@ -22,6 +22,7 @@ apt-get install -y --no-install-recommends \
 # This line is intentionally empty to preserve trailing \ in previous list
 
 bash /src/docker/scripts/install_node.sh
+bash /src/docker/scripts/install_multi_start.sh
 
 # Allow the next script to run as ${USER}
 chown -R "${USER}":"${GROUP}" /src

--- a/nodejs-base/ubuntu22.04-node18/docker/scripts/install_multi_start.sh
+++ b/nodejs-base/ubuntu22.04-node18/docker/scripts/install_multi_start.sh
@@ -4,7 +4,10 @@
 set -exuo pipefail
 
 # Install pipx
-apt-get update && apt-get install -y python3-pip python3-venv
+apt-get update
+apt-get install -y \
+    python3-pip \
+    python3-venv
 python3 -m pip install --user -U pipx
 /root/.local/bin/pipx ensurepath
 export PATH="/root/.local/bin:$PATH"

--- a/nodejs-base/ubuntu22.04-node18/docker/scripts/install_multi_start.sh
+++ b/nodejs-base/ubuntu22.04-node18/docker/scripts/install_multi_start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+# Install pipx
+apt-get update && apt-get install -y python3-pip python3-venv
+python3 -m pip install --user -U pipx
+/root/.local/bin/pipx ensurepath
+export PATH="/root/.local/bin:$PATH"
+
+# Install multi-start and make it available for all users
+PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install multi-start
+
+# cleanup
+apt-get remove -y python3-pip


### PR DESCRIPTION
```
~/w/d/docker-images master• 1m 3.1s  
 ❱ docker run -it --rm docker.io/library/nodejs-base:ubuntu22.04-node18 /bin/bash
root@4384916d9822:/src# multi-start
At least one service must be enabled
root@4384916d9822:/src# ^C
```