### PR TITLE
Hotfix: Lock pnpm to 8.6.12

### DIFF
--- a/nodejs-base/ubuntu22.04-node18/docker/scripts/install_node.sh
+++ b/nodejs-base/ubuntu22.04-node18/docker/scripts/install_node.sh
@@ -11,4 +11,4 @@ apt-get update
 apt-get install -y --no-install-recommends nodejs
 
 # Install sane package managers
-npm install -g pnpm yarn
+npm install -g pnpm@8.6.12 yarn

--- a/python-base/ubuntu22.04-python3.10-nginx-node18/docker/scripts/install_node.sh
+++ b/python-base/ubuntu22.04-python3.10-nginx-node18/docker/scripts/install_node.sh
@@ -11,4 +11,4 @@ apt-get update
 apt-get install -y --no-install-recommends nodejs
 
 # Install sane package managers
-npm install -g pnpm yarn
+npm install -g pnpm@@8.6.12 yarn

--- a/python-base/ubuntu22.04-python3.10-nginx-node18/docker/scripts/install_node.sh
+++ b/python-base/ubuntu22.04-python3.10-nginx-node18/docker/scripts/install_node.sh
@@ -11,4 +11,4 @@ apt-get update
 apt-get install -y --no-install-recommends nodejs
 
 # Install sane package managers
-npm install -g pnpm@@8.6.12 yarn
+npm install -g pnpm@8.6.12 yarn


### PR DESCRIPTION
The 8.7.0 version fails to install frozen lockfiles created by 8.6.x.

See https://github.com/pnpm/pnpm/issues/6990 for more details.