### PR TITLE
Added Python 3.11 base image

### DIFF
--- a/python-base/ubuntu22.04-python3.11/.trivyignore
+++ b/python-base/ubuntu22.04-python3.11/.trivyignore
@@ -1,0 +1,4 @@
+# Unfixable atm: https://avd.aquasec.com/nvd/2022/cve-2022-42919/
+CVE-2022-42919
+# Not relevant: https://avd.aquasec.com/nvd/2022/cve-2022-40897/
+CVE-2022-40897

--- a/python-base/ubuntu22.04-python3.11/Dockerfile
+++ b/python-base/ubuntu22.04-python3.11/Dockerfile
@@ -1,0 +1,32 @@
+ARG LOCAL_REGISTRY=""
+FROM ${LOCAL_REGISTRY}ubuntu-base:22.04
+
+ENV \
+    DEBIAN_FRONTEND="noninteractive" \
+    GID=1000 \
+    GROUP="api" \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
+    POETRY_HOME="/usr/local/poetry" \
+    POETRY_VERSION="1.5.1" \
+    PYTHONUNBUFFERED=1 \
+    PYTHON_VERSION="3.11" \
+    TZ="UTC" \
+    UID=1000 \
+    USER="api" \
+    WORKON_HOME="/.venv" \
+    # Workardound for issue with broken virtual environments. For more details see:
+    # https://github.com/python-poetry/install.python-poetry.org/blob/main/README.md#debianubuntu
+    # https://github.com/python-poetry/poetry/issues/6371#issuecomment-1235764346
+    DEB_PYTHON_INSTALL_LAYOUT=deb \
+    ENV_LAST_LINE="LEAVE-ME-HERE"
+
+# Run docker/base-prepare.sh
+WORKDIR /src/
+COPY docker /src/docker
+RUN : \
+ && set -exu \
+ && bash /src/docker/base-prepare.sh \
+ && rm -rf /src/docker \
+ && :

--- a/python-base/ubuntu22.04-python3.11/config.yaml
+++ b/python-base/ubuntu22.04-python3.11/config.yaml
@@ -1,0 +1,4 @@
+tags:
+  - ubuntu-python3.11
+  - ubuntu-python3.11-poetry1.5.1
+  - ubuntu22.04-python3.11-poetry1.5.1

--- a/python-base/ubuntu22.04-python3.11/docker/base-prepare.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/base-prepare.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# WARNING!
+# ========
+#
+# THIS FILE IS NOT USED IN RUNTIME, ONLY WHILE BUILDING DOCKER IMAGES
+# DO NOT ADD ANYTHING RUNTIME OR ENVIRONMENT SPECIFIC HERE
+#
+# This file is for installing the larger dependencies that rarely change such
+# as OS packages, utilities and so on, for the build environment
+#
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+bash /src/docker/scripts/create_user.sh
+
+apt-get update
+apt-get upgrade -y
+apt-get install -y --no-install-recommends \
+  curl \
+  ca-certificates \
+# This line is intentionally empty to preserve trailing \ in previous list
+
+bash /src/docker/scripts/install_python.sh
+bash /src/docker/scripts/prepare_workon_dir.sh
+bash /src/docker/scripts/install_poetry.sh
+bash /src/docker/scripts/install_multi_start.sh
+
+# Allow the next script to run as ${USER}
+chown -R "${USER}":"${GROUP}" /src
+
+bash /src/docker/scripts/configure_poetry.sh
+
+# Cleanup
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+rm -rf /root/.cache
+rm -rf /usr/share/doc

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/configure_poetry.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/configure_poetry.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+su "${USER}" -c ". ${POETRY_HOME}/env; poetry config virtualenvs.in-project false"
+su "${USER}" -c ". ${POETRY_HOME}/env; poetry config virtualenvs.path ${WORKON_HOME}"

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/create_user.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/create_user.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+# Create user
+addgroup --system --gid "${GID}" "${GROUP}"
+useradd \
+  --uid "${UID}" \
+  --shell /bin/bash \
+  --gid "${GID}" \
+  --create-home \
+  "${USER}"

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/install_multi_start.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/install_multi_start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+# Install pipx
+"python${PYTHON_VERSION}" -m pip install --user -U pipx
+/root/.local/bin/pipx ensurepath
+export PATH="/root/.local/bin:$PATH"
+
+# Install multi-start and make it available for all users
+PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install multi-start

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/install_poetry.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+POETRY_URL="https://install.python-poetry.org"
+
+mkdir "${POETRY_HOME}"
+chown -R "${USER}":"${GROUP}" "${POETRY_HOME}"
+
+su "${USER}" -c "curl -sSL ${POETRY_URL} | python - --version ${POETRY_VERSION}"
+# Create the env file manually; installers prior to 1.2.0 created this by default
+su "${USER}" -c "echo \"export PATH=\\\"${POETRY_HOME}/bin:\\\$PATH\\\"\" > \"${POETRY_HOME}/env\""
+
+chmod +x "${POETRY_HOME}"/bin/*
+bash /src/docker/scripts/configure_poetry.sh

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/install_python.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/install_python.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+# Install python
+apt-get install -y --no-install-recommends \
+  "python${PYTHON_VERSION}" \
+  "python${PYTHON_VERSION}-venv" \
+  python3-distutils
+
+# Set python active
+update-alternatives --install /usr/bin/python python "/usr/bin/python${PYTHON_VERSION}" 10
+
+# Install Pip
+curl https://bootstrap.pypa.io/get-pip.py | python

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/prepare_workon_dir.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/prepare_workon_dir.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2039
+set -exuo pipefail
+
+# Ensure the WORKON_HOME exists, is empty and owned by ${USER}
+if [[ ! -d "${WORKON_HOME}" ]]; then
+  mkdir "${WORKON_HOME}"
+fi
+rm -rf "${WORKON_HOME:?}"/*
+chown -R "${USER}":"${GROUP}" "${WORKON_HOME}"

--- a/settings.py
+++ b/settings.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
         [
             "python-base/ubuntu20.04-python3.9",
             "python-base/ubuntu22.04-python3.10",
+            "python-base/ubuntu22.04-python3.11",
         ],
         [
             "python-base/ubuntu22.04-python3.10-nginx",


### PR DESCRIPTION
The diff vs `3.10` images are as follows

`Dockerfile`:
```diff
<     PYTHON_VERSION="3.10" \
---
>     PYTHON_VERSION="3.11" \
```
`docker/scripts/install_multi_start_sh`:
```diff
< python3.10 -m pip install --user -U pipx
---
> "python${PYTHON_VERSION}" -m pip install --user -U pipx
```
