### PR TITLE
Fix Python 3.11 install, update Poetry to 1.8.2, and add it to PATH

### DIFF
--- a/nodejs-base/ubuntu22.04-node18/.trivyignore
+++ b/nodejs-base/ubuntu22.04-node18/.trivyignore
@@ -12,3 +12,6 @@ CVE-2023-0286
 
 # pypa-setuptools: Regular Expression Denial of Service (ReDoS) in package_index.py
 CVE-2022-40897
+
+# Kernel vulnerability that likely does not affect us and no update yet
+CVE-2024-26597

--- a/python-base/ubuntu20.04-python3.9/Dockerfile
+++ b/python-base/ubuntu20.04-python3.9/Dockerfile
@@ -9,7 +9,7 @@ ENV \
     LC_ALL=C.UTF-8 \
     PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
     POETRY_HOME="/usr/local/poetry" \
-    POETRY_VERSION="1.5.1" \
+    POETRY_VERSION="1.8.2" \
     PYTHONUNBUFFERED=1 \
     PYTHON_VERSION="3.9" \
     TZ="UTC" \

--- a/python-base/ubuntu20.04-python3.9/config.yaml
+++ b/python-base/ubuntu20.04-python3.9/config.yaml
@@ -1,9 +1,9 @@
 tags:
   - ubuntu20.04-python
   - ubuntu-python3.9
-  - poetry1.5.1
-  - lts-poetry1.5.1
-  - ubuntu-python-poetry1.5.1
-  - ubuntu-python3.9-poetry1.5.1
-  - ubuntu20.04-python-poetry1.5.1
-  - ubuntu20.04-python3.9-poetry1.5.1
+  - poetry1.8.2
+  - lts-poetry1.8.2
+  - ubuntu-python-poetry1.8.2
+  - ubuntu-python3.9-poetry1.8.2
+  - ubuntu20.04-python-poetry1.8.2
+  - ubuntu20.04-python3.9-poetry1.8.2

--- a/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
@@ -13,4 +13,8 @@ su "${USER}" -c "curl -sSL ${POETRY_URL} | python - --version ${POETRY_VERSION}"
 su "${USER}" -c "echo \"export PATH=\\\"${POETRY_HOME}/bin:\\\$PATH\\\"\" > \"${POETRY_HOME}/env\""
 
 chmod +x "${POETRY_HOME}"/bin/*
+
+# Make poetry available from PATH always
+ln -sf "${POETRY_HOME}/bin/poetry" /usr/bin/poetry
+
 bash /src/docker/scripts/configure_poetry.sh

--- a/python-base/ubuntu22.04-python3.10-nginx-node18/config.yaml
+++ b/python-base/ubuntu22.04-python3.10-nginx-node18/config.yaml
@@ -3,9 +3,9 @@ tags:
   - ubuntu22.04-python-nginx-node18
   - lts-python-nginx-node18
   - ubuntu-python3.10-nginx-node18
-  - poetry1.5.1-nginx-node18
-  - lts-poetry1.5.1-nginx-node18
-  - ubuntu-python-poetry1.5.1-nginx-node18
-  - ubuntu-python3.10-poetry1.5.1-nginx-node18
-  - ubuntu22.04-python-poetry1.5.1-nginx-node18
-  - ubuntu22.04-python3.10-poetry1.5.1-nginx-node18
+  - poetry1.8.2-nginx-node18
+  - lts-poetry1.8.2-nginx-node18
+  - ubuntu-python-poetry1.8.2-nginx-node18
+  - ubuntu-python3.10-poetry1.8.2-nginx-node18
+  - ubuntu22.04-python-poetry1.8.2-nginx-node18
+  - ubuntu22.04-python3.10-poetry1.8.2-nginx-node18

--- a/python-base/ubuntu22.04-python3.10-nginx/config.yaml
+++ b/python-base/ubuntu22.04-python3.10-nginx/config.yaml
@@ -3,9 +3,9 @@ tags:
   - ubuntu22.04-python-nginx
   - lts-python-nginx
   - ubuntu-python3.10-nginx
-  - poetry1.5.1-nginx
-  - lts-poetry1.5.1-nginx
-  - ubuntu-python-poetry1.5.1-nginx
-  - ubuntu-python3.10-poetry1.5.1-nginx
-  - ubuntu22.04-python-poetry1.5.1-nginx
-  - ubuntu22.04-python3.10-poetry1.5.1-nginx
+  - poetry1.8.2-nginx
+  - lts-poetry1.8.2-nginx
+  - ubuntu-python-poetry1.8.2-nginx
+  - ubuntu-python3.10-poetry1.8.2-nginx
+  - ubuntu22.04-python-poetry1.8.2-nginx
+  - ubuntu22.04-python3.10-poetry1.8.2-nginx

--- a/python-base/ubuntu22.04-python3.10/Dockerfile
+++ b/python-base/ubuntu22.04-python3.10/Dockerfile
@@ -9,7 +9,7 @@ ENV \
     LC_ALL=C.UTF-8 \
     PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
     POETRY_HOME="/usr/local/poetry" \
-    POETRY_VERSION="1.5.1" \
+    POETRY_VERSION="1.8.2" \
     PYTHONUNBUFFERED=1 \
     PYTHON_VERSION="3.10" \
     TZ="UTC" \

--- a/python-base/ubuntu22.04-python3.10/config.yaml
+++ b/python-base/ubuntu22.04-python3.10/config.yaml
@@ -1,4 +1,4 @@
 tags:
   - ubuntu-python3.10
-  - ubuntu-python3.10-poetry1.5.1
-  - ubuntu22.04-python3.10-poetry1.5.1
+  - ubuntu-python3.10-poetry1.8.2
+  - ubuntu22.04-python3.10-poetry1.8.2

--- a/python-base/ubuntu22.04-python3.10/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu22.04-python3.10/docker/scripts/install_poetry.sh
@@ -13,4 +13,8 @@ su "${USER}" -c "curl -sSL ${POETRY_URL} | python - --version ${POETRY_VERSION}"
 su "${USER}" -c "echo \"export PATH=\\\"${POETRY_HOME}/bin:\\\$PATH\\\"\" > \"${POETRY_HOME}/env\""
 
 chmod +x "${POETRY_HOME}"/bin/*
+
+# Make poetry available from PATH always
+ln -sf "${POETRY_HOME}/bin/poetry" /usr/bin/poetry
+
 bash /src/docker/scripts/configure_poetry.sh

--- a/python-base/ubuntu22.04-python3.11/Dockerfile
+++ b/python-base/ubuntu22.04-python3.11/Dockerfile
@@ -9,7 +9,7 @@ ENV \
     LC_ALL=C.UTF-8 \
     PATH="${PATH}:/.venv:/usr/local/poetry/bin" \
     POETRY_HOME="/usr/local/poetry" \
-    POETRY_VERSION="1.7.1" \
+    POETRY_VERSION="1.8.2" \
     PYTHONUNBUFFERED=1 \
     PYTHON_VERSION="3.11" \
     TZ="UTC" \

--- a/python-base/ubuntu22.04-python3.11/config.yaml
+++ b/python-base/ubuntu22.04-python3.11/config.yaml
@@ -1,4 +1,4 @@
 tags:
   - ubuntu-python3.11
-  - ubuntu-python3.11-poetry1.7.1
-  - ubuntu22.04-python3.11-poetry1.7.1
+  - ubuntu-python3.11-poetry1.8.2
+  - ubuntu22.04-python3.11-poetry1.8.2

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/install_poetry.sh
@@ -13,4 +13,8 @@ su "${USER}" -c "curl -sSL ${POETRY_URL} | python - --version ${POETRY_VERSION}"
 su "${USER}" -c "echo \"export PATH=\\\"${POETRY_HOME}/bin:\\\$PATH\\\"\" > \"${POETRY_HOME}/env\""
 
 chmod +x "${POETRY_HOME}"/bin/*
+
+# Make poetry available from PATH always
+ln -sf "${POETRY_HOME}/bin/poetry" /usr/bin/poetry
+
 bash /src/docker/scripts/configure_poetry.sh

--- a/python-base/ubuntu22.04-python3.11/docker/scripts/install_python.sh
+++ b/python-base/ubuntu22.04-python3.11/docker/scripts/install_python.sh
@@ -3,6 +3,10 @@
 # shellcheck disable=SC2039
 set -exuo pipefail
 
+# Deadsnakes PPA is the only way to get stable Python 3.11 for Ubuntu 22.04
+apt-get install -y software-properties-common
+add-apt-repository ppa:deadsnakes/ppa -y
+
 # Install python
 apt-get install -y --no-install-recommends \
   "python${PYTHON_VERSION}" \


### PR DESCRIPTION
- Python 3.11 was previously installed as 3.11.0rc1, now -> 3.11.8+ from deadsnakes PPA
- Old Poetry had issues installing packages from extra registries, updated to 1.8.2
- Installed poetry to /usr/bin