### PR TITLE
Hotfix: Lock quemu to a version that does not segfault

### DIFF
--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -56,7 +56,13 @@ jobs:
         run: regctl version
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
+        with:
+          # For now hardcoding the image to the latest version found in a successful run of the action, it seems like
+          # it is using quemu v7.0.0. The "tonistiigi/binfmt:latest" with qemu-v9.2.0 runs into this error:
+          # Setting up libc-bin (2.35-0ubuntu3.9) ...
+          # qemu: uncaught target signal 11 (Segmentation fault) - core dumped
+          image: "tonistiigi/binfmt@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
The build pipeline started failing recently. It was crashing with this error:
```
45.34 Preparing to unpack .../libc-bin_2.35-0ubuntu3.9_arm64.deb ...
45.35 Unpacking libc-bin (2.35-0ubuntu3.9) over (2.35-0ubuntu3.8) ...
45.60 Setting up libc-bin (2.35-0ubuntu3.9) ...
45.73 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
46.18 Segmentation fault (core dumped)
46.24 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
46.60 Segmentation fault (core dumped)
Sub-process /usr/bin/dpkg returned an error code (1)
```

I managed to dig a working version from the history of successful builds. If I managed to check correctlu that was using quemu 7.0.0 and the default version used (":latest") was using 9.2.0.

Doesn't seem like there's any tags any longer for the 7.0.0 images. I also made one failed attempt at using v8.1.5, for which there was a tag. Good enough like this for now, let's later get back to this and try to find a more elegant solution.