### PR TITLE
Revert to pnpm 9

### DIFF
--- a/nodejs-base/ubuntu22.04-node18/docker/scripts/install_node.sh
+++ b/nodejs-base/ubuntu22.04-node18/docker/scripts/install_node.sh
@@ -11,4 +11,4 @@ apt-get update
 apt-get install -y --no-install-recommends nodejs
 
 # Install sane package managers
-npm install -g pnpm yarn
+npm install -g pnpm@latest-9 yarn


### PR DESCRIPTION
Seems like pnpm 10 was recently released and it dropped support for the lockfile version 6. Pnpm 9 still supports that.